### PR TITLE
Module Fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,9 +71,9 @@ jar {
                 'Bundle-License'        : 'https://www.apache.org/licenses/LICENSE-2.0;description=Apache License Version 2.0;link=https://spdx.org/licenses/Apache-2.0.html',
                 'Bundle-Description'    : description,
                 'Bundle-SymbolicName'   : 'eu.hansolo.toolboxfx',
-                'Export-Package'        : 'eu.hansolo.toolboxfx,eu.hansolo.toolboxfx.geom,eu.hansolo.toolboxfx.font',
+                'Export-Package'        : 'eu.hansolo.toolboxfx, eu.hansolo.toolboxfx.geom, eu.hansolo.toolboxfx.font, eu.hansolo.toolboxfx.evt.type',
                 'Class-Path'            : configurations.runtimeClasspath.files.collect { it.getName() }.join(' '),
-                'Main-Class'            : '${mainClassName}'
+                'Main-Class'            : "${mainClassName}"
         )
     }
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -12,9 +12,13 @@ module eu.hansolo.toolboxfx {
     requires transitive eu.hansolo.toolbox;
 
     opens eu.hansolo.toolboxfx to eu.hansolo.toolbox;
+    opens eu.hansolo.toolboxfx.evt.type to eu.hansolo.toolbox;
+    opens eu.hansolo.toolboxfx.font to eu.hansolo.toolbox;
+    opens eu.hansolo.toolboxfx.geom to eu.hansolo.toolbox;
 
-    exports eu.hansolo.toolboxfx.font;
-    exports eu.hansolo.toolboxfx.evt.type;
-    exports eu.hansolo.toolboxfx.geom;
     exports eu.hansolo.toolboxfx;
+    exports eu.hansolo.toolboxfx.evt.type;
+    exports eu.hansolo.toolboxfx.font;
+    exports eu.hansolo.toolboxfx.geom;
+
 }


### PR DESCRIPTION
This is a follow on to HanSolo/charts#109

This PR is 2/4 in an attempt to fix the following error I was getting when performing jlink of [Birdasaur/Trinity](https://github.com/Birdasaur/Trinity) with the latest charts (17.1.47). Realized this propagated from toolbox all the way to charts, so I apolize for the bunch of PR's. Note charts, countries were failing to jlink as well.

The error looked something like this, but it got better as I kept adding missing opens/exports:
```
Module eu.hansolo.fx.countries contains package eu.hansolo.toolboxfx, module eu.hansolo.toolboxfx exports package eu.hansolo.toolboxfx to eu.hansolo.fx.countries
```

Edit (linking other PRs):
https://github.com/HanSolo/toolbox/pull/1
https://github.com/HanSolo/countries/pull/8
https://github.com/HanSolo/charts/pull/110
