### PR TITLE
streamline dependency/module graph

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ repositories {
 }
 
 dependencies {
-    implementation "eu.hansolo:toolbox:17.0.55"
+    api "eu.hansolo:toolbox:17.0.55"
     implementation "org.openjfx:javafx-base:${javafxVersion}:${platform}"
     implementation "org.openjfx:javafx-graphics:${javafxVersion}:${platform}"
     implementation "org.openjfx:javafx-controls:${javafxVersion}:${platform}"

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -3,10 +3,10 @@ module eu.hansolo.toolboxfx {
     requires java.base;
 
     // Java-FX
-    requires transitive javafx.base;
-    requires transitive javafx.graphics;
-    requires transitive javafx.controls;
-    requires transitive javafx.swing;
+    requires javafx.base;
+    requires javafx.graphics;
+    requires javafx.controls;
+    requires javafx.swing;
 
     // 3rd Party
     requires transitive eu.hansolo.toolbox;


### PR DESCRIPTION
PR 1/4

This will help streamline the dependency graph across dependencies by using api configuration per gradle [docs](https://docs.gradle.org/current/userguide/java_library_plugin.html#declaring_module_dependencies).

This allows the end user to only have to type `implementation 'eu.hansolo:toolboxfx:17.0.45'` to get all the needed dependencies.

![dg-toolboxfx](https://github.com/HanSolo/toolboxfx/assets/3933065/197ccc2a-9948-4332-8efd-4041ce3d6cec)
