### PR TITLE
Fix Manifest Description

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ jar {
                 'Implementation-Version': project.version,
                 'Bundle-Name'           : project.name,
                 'Bundle-License'        : 'https://www.apache.org/licenses/LICENSE-2.0;description=Apache License Version 2.0;link=https://spdx.org/licenses/Apache-2.0.html',
-                'Bundle-Description'    : description,
+                'Bundle-Description'    : project.description,
                 'Bundle-SymbolicName'   : 'eu.hansolo.toolboxfx',
                 'Export-Package'        : 'eu.hansolo.toolboxfx, eu.hansolo.toolboxfx.geom, eu.hansolo.toolboxfx.font, eu.hansolo.toolboxfx.evt.type',
                 'Class-Path'            : "${project.name}-${project.version}.jar",


### PR DESCRIPTION
The manifest would look like this for the description:

`Bundle-Description: Assembles a jar archive containing the classes of the 'main' feature.`